### PR TITLE
Add brine_init_keypair_from_seed function

### DIFF
--- a/c_src/brine_nif.c
+++ b/c_src/brine_nif.c
@@ -53,6 +53,7 @@ static ERL_NIF_TERM BRINE_ERROR_NO_MEMORY;
 
 // NIF function forward declares
 NIF(bnif_generate_keypair);
+NIF(bnif_generate_keypair_from_seed);
 NIF(bnif_sign_message);
 NIF(bnif_verify_signature);
 NIF(bnif_to_binary);
@@ -61,6 +62,7 @@ NIF(bnif_to_keypair);
 static ErlNifFunc nif_funcs[] =
 {
   {"generate_keypair", 2, bnif_generate_keypair},
+  {"generate_keypair_from_seed", 3, bnif_generate_keypair_from_seed},
   {"sign_message", 4, bnif_sign_message},
   {"verify_signature", 5, bnif_verify_signature},
   {"to_binary", 3, bnif_to_binary},
@@ -94,6 +96,32 @@ static void generate_keypair(brine_task_s *task) {
     }
     else {
       result = enif_make_tuple2(env, enif_make_copy(env, BRINE_ATOM_OK), make_keypair_record(env, keypair));
+    }
+    enif_release_resource(keypair);
+  }
+  enif_send(NULL, &task->owner, task->env, enif_make_tuple2(env, task->ref, result));
+}
+
+static void generate_keypair_from_seed(brine_task_s *task) {
+  ErlNifEnv *env = task->env;
+  ERL_NIF_TERM result;
+  brine_keypair_s *keypair = (brine_keypair_s *) enif_alloc_resource(brine_keypair_resource, sizeof(brine_keypair_s));
+  ErlNifBinary seed;
+
+  if (!keypair) {
+    result = BRINE_ERROR_NO_MEMORY;
+  }
+  else {
+    if (!enif_inspect_binary(env, task->options.generate.seed, &seed)) {
+      result = BRINE_ATOM_ERROR;
+    }
+    else {
+      if (!brine_init_keypair_from_seed(keypair, seed.data, seed.size)) {
+        result = BRINE_ATOM_ERROR;
+      }
+      else {
+        result = enif_make_tuple2(env, enif_make_copy(env, BRINE_ATOM_OK), make_keypair_record(env, keypair));
+      }
     }
     enif_release_resource(keypair);
   }
@@ -202,6 +230,9 @@ static void *worker_loop(void *ignored) {
     case BRINE_NEW_KEYPAIR:
       generate_keypair(task);
       break;
+    case BRINE_NEW_KEYPAIR_FROM_SEED:
+      generate_keypair_from_seed(task);
+      break;
     case BRINE_SIGN_MSG:
       sign_message(task);
       break;
@@ -243,6 +274,25 @@ NIF(bnif_generate_keypair) {
 
   brine_task_s *task = brine_task_new(&owner, BRINE_NEW_KEYPAIR, argv[1]);
   if (task) {
+    if (brine_queue_enqueue(queue, task) != BQ_SUCCESS) {
+      return make_error_tuple(env, enif_make_atom(env, "overload"));
+    }
+    return BRINE_ATOM_OK;
+  }
+  return BRINE_ATOM_ERROR;
+}
+
+NIF(bnif_generate_keypair_from_seed) {
+  ErlNifPid owner;
+
+  if (!enif_get_local_pid(env, argv[0], &owner) ||
+      !enif_is_ref(env, argv[1])) {
+    return enif_make_badarg(env);
+  }
+
+  brine_task_s *task = brine_task_new(&owner, BRINE_NEW_KEYPAIR_FROM_SEED, argv[1]);
+  if (task) {
+    task->options.generate.seed = enif_make_copy(task->env, argv[2]);
     if (brine_queue_enqueue(queue, task) != BQ_SUCCESS) {
       return make_error_tuple(env, enif_make_atom(env, "overload"));
     }

--- a/c_src/brine_task.h
+++ b/c_src/brine_task.h
@@ -32,11 +32,16 @@
 typedef enum brine_cmd_e {
   BRINE_STOP,
   BRINE_NEW_KEYPAIR,
+  BRINE_NEW_KEYPAIR_FROM_SEED,
   BRINE_SIGN_MSG,
   BRINE_VERIFY,
   BRINE_TO_BINARY,
   BRINE_TO_KEYPAIR
 } brine_task_cmd_e;
+
+typedef struct {
+    ERL_NIF_TERM seed;
+} brine_generate_s;
 
 typedef struct {
   brine_keypair_s *keys;
@@ -55,6 +60,7 @@ typedef struct {
   brine_task_cmd_e cmd;
   ERL_NIF_TERM ref;
   union {
+    brine_generate_s generate;
     brine_task_sig_s signature;
     brine_task_verify_s verify;
   } options;

--- a/src/brine.erl
+++ b/src/brine.erl
@@ -37,6 +37,7 @@
 -include_lib("brine/include/brine.hrl").
 
 -export([new_keypair/0,
+         new_keypair/1,
          sign_message/2,
          sign_message_hex/2,
          verify_signature/3,
@@ -62,6 +63,12 @@ new_keypair() ->
     Owner = self(),
     Ref = erlang:make_ref(),
     ?complete_nif_call(Ref, brine_nif:generate_keypair(Owner, Ref)).
+
+-spec new_keypair(binary()) -> {ok, #brine_keypair{}} | {error, term()}.
+new_keypair(Seed) ->
+    Owner = self(),
+    Ref = erlang:make_ref(),
+    ?complete_nif_call(Ref, brine_nif:generate_keypair_from_seed(Owner, Ref, Seed)).
 
 -spec sign_message(#brine_keypair{}, binary()) -> {ok, signature()} | {error, term()}.
 sign_message(#brine_keypair{handle=H}, Message) ->

--- a/src/brine_nif.erl
+++ b/src/brine_nif.erl
@@ -24,6 +24,7 @@
 
 -export([init/0,
          generate_keypair/2,
+         generate_keypair_from_seed/3,
          sign_message/4,
          verify_signature/5,
          to_binary/3,
@@ -41,6 +42,9 @@ init() ->
     end.
 
 generate_keypair(_Caller, _Ref) ->
+    ?nif_error.
+
+generate_keypair_from_seed(_Caller, _Ref, _Seed) ->
     ?nif_error.
 
 sign_message(_Caller, _Ref, _KeyPair, _Message) ->


### PR DESCRIPTION
This allows you to generate a keypair given a pre-existing secret. You need to provide it with a 32-byte binary term.
